### PR TITLE
[FEAT] NaivationController에서 Animation으로 변경

### DIFF
--- a/Subvey_Mission.xcodeproj/project.pbxproj
+++ b/Subvey_Mission.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		18B62F8B2B6BBCB600DE67B0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18B62F8A2B6BBCB600DE67B0 /* SnapKit */; };
 		18B6EB5C2B6A5B6000F62458 /* APIHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B6EB5B2B6A5B6000F62458 /* APIHandler.swift */; };
 		18B94DAB2B6CBA3A00EEDCF6 /* QuestionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B94DAA2B6CBA3A00EEDCF6 /* QuestionViewController.swift */; };
+		18D327F32B7205B80095823E /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D327F22B7205B80095823E /* Animatable.swift */; };
+		18D327F52B721EAA0095823E /* FormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D327F42B721EAA0095823E /* FormView.swift */; };
 		18D56EFE2B69234400B19F24 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D56EFD2B69234400B19F24 /* AppDelegate.swift */; };
 		18D56F002B69234400B19F24 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D56EFF2B69234400B19F24 /* SceneDelegate.swift */; };
 		18D56F022B69234400B19F24 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D56F012B69234400B19F24 /* ViewController.swift */; };
@@ -20,6 +22,8 @@
 /* Begin PBXFileReference section */
 		18B6EB5B2B6A5B6000F62458 /* APIHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHandler.swift; sourceTree = "<group>"; };
 		18B94DAA2B6CBA3A00EEDCF6 /* QuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionViewController.swift; sourceTree = "<group>"; };
+		18D327F22B7205B80095823E /* Animatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animatable.swift; sourceTree = "<group>"; };
+		18D327F42B721EAA0095823E /* FormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormView.swift; sourceTree = "<group>"; };
 		18D56EFA2B69234400B19F24 /* Subvey_Mission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Subvey_Mission.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		18D56EFD2B69234400B19F24 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		18D56EFF2B69234400B19F24 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -63,11 +67,13 @@
 				18D56EFD2B69234400B19F24 /* AppDelegate.swift */,
 				18D56EFF2B69234400B19F24 /* SceneDelegate.swift */,
 				18D56F012B69234400B19F24 /* ViewController.swift */,
+				18D327F22B7205B80095823E /* Animatable.swift */,
 				18B94DAA2B6CBA3A00EEDCF6 /* QuestionViewController.swift */,
 				18B6EB5B2B6A5B6000F62458 /* APIHandler.swift */,
 				18D56F062B69234600B19F24 /* Assets.xcassets */,
 				18D56F082B69234600B19F24 /* LaunchScreen.storyboard */,
 				18D56F0B2B69234600B19F24 /* Info.plist */,
+				18D327F42B721EAA0095823E /* FormView.swift */,
 			);
 			path = Subvey_Mission;
 			sourceTree = "<group>";
@@ -149,6 +155,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				18B94DAB2B6CBA3A00EEDCF6 /* QuestionViewController.swift in Sources */,
+				18D327F32B7205B80095823E /* Animatable.swift in Sources */,
+				18D327F52B721EAA0095823E /* FormView.swift in Sources */,
 				18D56F022B69234400B19F24 /* ViewController.swift in Sources */,
 				18B6EB5C2B6A5B6000F62458 /* APIHandler.swift in Sources */,
 				18D56EFE2B69234400B19F24 /* AppDelegate.swift in Sources */,

--- a/Subvey_Mission/APIHandler.swift
+++ b/Subvey_Mission/APIHandler.swift
@@ -39,7 +39,6 @@ struct APIHandler {
                 return
             }
             guard let data else { return }
-            print(String(data: data, encoding: .utf8))
             let decoder = JSONDecoder()
             do {
                 let question = try decoder.decode(T.self, from: data)

--- a/Subvey_Mission/Animatable.swift
+++ b/Subvey_Mission/Animatable.swift
@@ -1,0 +1,12 @@
+//
+//  Animatable.swift
+//  Subvey_Mission
+//
+//  Created by 김도현 on 2024/02/06.
+//
+
+import Foundation
+
+protocol QuestionList {
+    func next()
+}

--- a/Subvey_Mission/FormView.swift
+++ b/Subvey_Mission/FormView.swift
@@ -1,0 +1,131 @@
+//
+//  FormView.swift
+//  Subvey_Mission
+//
+//  Created by 김도현 on 2024/02/06.
+//
+
+import UIKit
+import SnapKit
+
+class FormView: UIView, Animatable {
+    
+    enum state {
+        case next
+        case done
+        case other
+    }
+    
+    enum formType {
+        case text
+        case select
+        case multiSelect
+    }
+    
+    private let stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 12
+        stackView.distribution = .equalSpacing
+        return stackView
+    }()
+    
+    var inset: CGFloat = 16 {
+        didSet {
+            stackView.snp.updateConstraints { make in
+                make.edges.equalToSuperview().inset(inset)
+            }
+        }
+    }
+    var spacing: CGFloat = 16 {
+        didSet {
+            stackView.spacing = spacing
+        }
+    }
+    
+    var nextForm: Form? = nil
+    
+    init(views:[UIView], type: formType) {
+        super.init(frame: .zero)
+        views.forEach { view in
+            stackView.addArrangedSubview(view)
+        }
+        setAutoLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func next(nextForm: Form) {
+        
+        self.layer.removeAnimation(forKey: "move")
+        self.layer.removeAnimation(forKey: "fade")
+        
+        let moveLayer = stackView.layer
+        let moveAnimation = CABasicAnimation(keyPath: "position")
+
+        moveAnimation.byValue = NSValue(cgPoint: CGPoint(x: -100, y: 0))
+        moveAnimation.duration = 0.5
+        
+        let fadeAnimation = CABasicAnimation(keyPath: "opacity")
+        fadeAnimation.fromValue = 1.0
+        fadeAnimation.toValue = 0.0
+        fadeAnimation.duration = 0.5
+        
+        fadeAnimation.fillMode = .forwards
+        fadeAnimation.isRemovedOnCompletion = false
+        fadeAnimation.delegate = self
+        
+        let animations = [moveAnimation, fadeAnimation]
+        
+        self.layer.add(moveAnimation, forKey: "move")
+        self.layer.add(fadeAnimation, forKey: "fade")
+    }
+    
+    func nextQuestion() {
+        let moveAnimation = CABasicAnimation(keyPath: "position")
+        let center = center
+        
+        moveAnimation.fromValue = NSValue(cgPoint: CGPoint(x: center.x + 100, y: center.y))
+        moveAnimation.toValue = NSValue(cgPoint: center)
+        moveAnimation.duration = 0.5
+        
+        let fadeAnimation = CABasicAnimation(keyPath: "opacity")
+        fadeAnimation.toValue = 1.0
+        fadeAnimation.duration = 0.5
+        
+        fadeAnimation.fillMode = .forwards
+        fadeAnimation.isRemovedOnCompletion = false
+        
+        self.layer.add(moveAnimation, forKey: "next")
+        self.layer.add(fadeAnimation, forKey: "nextFade")
+    }
+}
+
+extension FormView: CAAnimationDelegate {
+    func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
+        if flag {
+            self.layer.removeAnimation(forKey: "next")
+            self.layer.removeAnimation(forKey: "nextFade")
+            nextQuestion()
+        }
+    }
+}
+
+extension FormView {
+    func addFormView(views: [UIView]) {
+        views.forEach { view in
+            stackView.addArrangedSubview(view)
+        }
+    }
+}
+private extension FormView {
+    func setAutoLayout() {
+        addSubview(stackView)
+        stackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(inset)
+        }
+    }
+}

--- a/Subvey_Mission/QuestionViewController.swift
+++ b/Subvey_Mission/QuestionViewController.swift
@@ -19,6 +19,8 @@ class QuestionViewController: UIViewController {
         field.textColor = .black
         return field
     }()
+    
+    private let formView: FormView = FormView(views: [], type: .text)
     private let btn: UIButton = {
         let btn = UIButton()
         btn.setTitle("next", for: .normal)
@@ -37,23 +39,33 @@ class QuestionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.addSubview(textField)
+        view.addSubview(formView)
         view.addSubview(btn)
         
-        textField.snp.makeConstraints { make in
+//        textField.snp.makeConstraints { make in
+//            make.center.equalTo(view.snp.center)
+//            make.left.right.equalToSuperview().inset(16)
+//
+//        }
+        formView.snp.makeConstraints { make in
             make.center.equalTo(view.snp.center)
             make.left.right.equalToSuperview().inset(16)
-
         }
+        
         btn.snp.makeConstraints { make in
-            make.top.equalTo(textField.snp.bottom).offset(10)
-            make.centerX.equalTo(textField.snp.centerX)
+            make.top.equalTo(formView.snp.bottom).offset(10)
+            make.centerX.equalTo(formView.snp.centerX)
             make.width.equalTo(60)
             make.height.equalTo(30)
         }
         
         if let currentForm = formManager.getCurrentForm() {
             btn.addTarget(self, action: #selector(nextQuestion), for: .touchUpInside)
+            
+            let questionView = UILabel()
+            questionView.font = .systemFont(ofSize: 16, weight: .regular)
+            questionView.text = currentForm.question
+            formView.addFormView(views: [questionView, textField])
             
             switch currentForm.placeholder {
             case .string(let placeholder):
@@ -95,8 +107,9 @@ class QuestionViewController: UIViewController {
         }
         formManager.updateValue(question: currentForm.question, answer: answer)
         formManager.nextQuestion()
-        let vc = QuestionViewController(formManager: formManager)
-        self.navigationController?.pushViewController(vc, animated: true)
+        formView.animate()
+//        let vc = QuestionViewController(formManager: formManager)
+//        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     @objc func doneQuestion() {

--- a/Subvey_Mission/ViewController.swift
+++ b/Subvey_Mission/ViewController.swift
@@ -21,7 +21,6 @@ class ViewController: UIViewController {
             self.formManager.forms = forms
             self.formManager.currentIndex = forms.isEmpty ? nil : 0
             DispatchQueue.main.async {
-//                self?.navigationController?.pushViewController(QuestionViewController(currentIndex: 0, forms: forms), animated: true)
                 self.navigationController?.pushViewController(QuestionViewController(formManager: self.formManager), animated: true)
             }
         }


### PR DESCRIPTION
NaivationController Push 를 사용하던 방법에서 애니메이션을 사용하여 화면이 이동하는것과 비슷한 효과를 주도록 변경

## 변경이유
1. Push를 사용하면 질문의 갯수만큼 ViewController가 쌓이게 되어 추가될수록 메모리에 문제가 생김
2. 질문을 작성도중 나가게 될 경우 다시 돌아올때 현재 질문 진행사항을 유지한채로 가져오고 싶을경우 navigationController로는 구현하기 어려운 문제가 있음